### PR TITLE
Downgrade to proto2 format

### DIFF
--- a/ddln_common.proto
+++ b/ddln_common.proto
@@ -1,21 +1,21 @@
-syntax = "proto3";
+syntax = "proto2";
 
 package ddln;
 
 message Point3d {
-    double x = 1;
-    double y = 2;
-    double z = 3;
+    required double x = 1;
+    required double y = 2;
+    required double z = 3;
 }
 
 message Quaternion {
-    double w = 1;
-    double x = 2;
-    double y = 3;
-    double z = 4;
+    required double w = 1;
+    required double x = 2;
+    required double y = 3;
+    required double z = 4;
 }
 
 message Pose {
-    Point3d position = 1;
-    Quaternion orientation = 2;
+    optional Point3d position = 1;
+    optional Quaternion orientation = 2;
 }

--- a/ddln_imaginator.proto
+++ b/ddln_imaginator.proto
@@ -1,11 +1,11 @@
-syntax = "proto3";
+syntax = "proto2";
 
 package ddln;
 
 import "ddln_common.proto";
 
 message Intrinsics {
-    float verticalFieldOfView_deg = 1;
+    required float verticalFieldOfView_deg = 1;
 }
 
 enum ImageFormat {
@@ -17,24 +17,24 @@ enum ImageFormat {
 }
 
 message ImageRequest {
-    ImageFormat format = 1;
-    uint32 width = 2;
-    uint32 height = 3;
-    Intrinsics intrinsics = 4;
-    Pose extrinsics_WC = 5;
+    required ImageFormat format = 1;
+    required uint32 width = 2;
+    required uint32 height = 3;
+    optional Intrinsics intrinsics = 4;
+    optional Pose extrinsics_WC = 5;
 }
 
 message ImageResponse {
-    bytes image = 1; // pixel array in requested format, 8UC1 for GRAY, 8UC3 for RGB/BGR, and so on.
+    required bytes image = 1; // pixel array in requested format, 8UC1 for GRAY, 8UC3 for RGB/BGR, and so on.
 }
 
 message WorldInfoRequest {
 }
 
 message WorldInfo {
-    string name = 1;
-    Point3d home = 2; // position in ENU coordinates of the home (geo referenced) point.
-    Point3d start = 3; // position in ENU coordinates of the SITL start location.
+    optional string name = 1;
+    optional Point3d home = 2; // position in ENU coordinates of the home (geo referenced) point.
+    optional Point3d start = 3; // position in ENU coordinates of the SITL start location.
 }
 
 service ImageService {

--- a/ddln_sitl.proto
+++ b/ddln_sitl.proto
@@ -1,12 +1,12 @@
-syntax = "proto3";
+syntax = "proto2";
 
 package ddln;
 
 import "ddln_common.proto";
 
 message UpdatePoseRequest {
-    int64 timestamp_ns = 1;
-    Pose pose_ENU = 2;
+    optional int64 timestamp_ns = 1;
+    optional Pose pose_ENU = 2;
 }
 
 message UpdatePoseResponse {


### PR DESCRIPTION
This is down so that older protobuf compilers can process these protos.
No functional changes, no wire format changes.