### PR TITLE
Added imaginator info service

### DIFF
--- a/ddln_imaginator.proto
+++ b/ddln_imaginator.proto
@@ -174,6 +174,7 @@ message ImageResponse {
     required bytes image = 1;
 }
 
+// World info message which contains world specific information
 message WorldInfo {
     optional string name = 1;
 
@@ -185,7 +186,45 @@ message WorldInfo {
     optional LatLongAlt home_geo = 4;
 }
 
+// Imaginator info message which contains imaginator specific information
+// This information is world agnostic and typically generated upon initialization
+message ImaginatorInfo {
+
+    // Reserved for future values such as version info and so on.
+    reserved 1, 2, 3, 4, 5, 6, 7, 8, 9;
+
+    // Object information message
+    message ObjectInfo {
+
+        // True if object info is customized, false in case information is left undefined, e.g. not specified.
+        // Contact sim@daedalean.ai if object information for a specific object key is required.
+        optional bool has_info = 1;
+
+        // Object full name
+        optional string name = 2;
+
+        // Optional short description of the object. Often left empty.
+        optional string description = 3;
+
+        // Annotation class as per Daedalean spotter ground truth annotation requirements
+        enum Class {
+            UNDEFINED = 0;
+            DRONE = 1;
+            BIRD = 3;
+            FIXED_WING = 4;
+            HELICOPTER = 5;
+            UNKNOWN = 100;
+        }
+        optional Class class = 4;
+
+        // Typical cruise velocity of the object. Value is left zero if undefined.
+        optional double cruise_velocity_m_s = 5;
+    }
+    map<string /* object unique key, e.g. SceneObject::type */, ObjectInfo> available_objects = 10;
+}
+
 service ImageService {
     rpc GenerateImage(ImageRequest) returns (ImageResponse);
     rpc GetWorldInfo(Empty) returns (WorldInfo);
+    rpc GetImaginatorInfo(Empty) returns (ImaginatorInfo);
 }


### PR DESCRIPTION
Implements interface definition for imaginator available objects service (T4238)

- Added imaginator info service
- Created available objects message as part of imaginator info. 